### PR TITLE
Make it possible to write into a container with a static shape.

### DIFF
--- a/echelon/hdf5/container_adaption.hpp
+++ b/echelon/hdf5/container_adaption.hpp
@@ -155,7 +155,7 @@ constexpr bool is_readable_container()
 template <typename T>
 constexpr bool is_container()
 {
-    return has_data_accessor<T>() && has_shape_property<T>() && has_reshape_member<T>();
+    return has_data_accessor<T>() && has_shape_property<T>();
 }
 }
 }

--- a/echelon/sink_adaptors.hpp
+++ b/echelon/sink_adaptors.hpp
@@ -15,6 +15,9 @@ template <typename ResizeableSink>
 class auto_reshaper
 {
 public:
+    static_assert(hdf5::has_reshape_member<ResizeableSink>(),
+                  "ResizeableSink does not fulfill the ResizeableSink requirements");
+
     explicit auto_reshaper(ResizeableSink& underlying_sink_) : underlying_sink_{&underlying_sink_}
     {
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,10 +67,12 @@ if(ECHELON_BUILD_TESTS)
   target_compile_options(null_state PRIVATE ${COVERAGE_FLAGS})
   target_link_libraries(null_state echelon ${Boost_LIBRARIES}  ${COVERAGE_LINKER_FLAGS})
   add_test(null_state ${CMAKE_CURRENT_BINARY_DIR}/null_state)
-  
+
   add_executable(dynamic_shape dynamic_shape.cpp)
   target_include_directories(dynamic_shape PUBLIC ${Boost_INCLUDE_DIRS})
   target_compile_options(dynamic_shape PRIVATE ${COVERAGE_FLAGS})
   target_link_libraries(dynamic_shape echelon ${Boost_LIBRARIES}  ${COVERAGE_LINKER_FLAGS})
   add_test(dynamic_shape ${CMAKE_CURRENT_BINARY_DIR}/dynamic_shape)
 endif()
+
+add_subdirectory(regression)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,0 +1,14 @@
+#  Copyright (c) 2015 Christopher Hinz
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(ECHELON_BUILD_TESTS)
+
+    add_executable(static_shape_writeable static_shape_writeable.cpp)
+    target_include_directories(static_shape_writeable PUBLIC ${Boost_INCLUDE_DIRS})
+    target_compile_options(static_shape_writeable PRIVATE ${COVERAGE_FLAGS})
+    target_link_libraries(static_shape_writeable echelon ${Boost_LIBRARIES} ${COVERAGE_LINKER_FLAGS})
+    add_test(static_shape_writeable ${CMAKE_CURRENT_BINARY_DIR}/static_shape_writeable)
+
+endif()

--- a/tests/regression/static_shape_writeable.cpp
+++ b/tests/regression/static_shape_writeable.cpp
@@ -1,0 +1,49 @@
+//  Copyright (c) 2015 Christopher Hinz
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_TEST_DYN_LINK
+
+#include <echelon/echelon.hpp>
+
+#define BOOST_TEST_MODULE "static shape writable regression test"
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+#include "../basic_fixture.hpp"
+
+struct static_shape_writable_fixture : basic_fixture
+{
+    static_shape_writable_fixture()
+    {
+        ds = temp_file.create_dataset<double>("dataset", {10, 10});
+    }
+
+    ~static_shape_writable_fixture()
+    {
+    }
+
+    echelon::dataset ds;
+};
+
+BOOST_AUTO_TEST_SUITE(static_shape_writable_suite)
+
+BOOST_FIXTURE_TEST_CASE(static_shape_writable_test, static_shape_writable_fixture)
+{
+    std::vector<double> data(100);
+    echelon::multi_array_view<double> data_view(data.data(), {10, 10});
+
+    data_view <<= ds;
+}
+
+BOOST_FIXTURE_TEST_CASE(static_shape_readable_test, static_shape_writable_fixture)
+{
+std::vector<double> data(100);
+echelon::multi_array_view<double> data_view(data.data(), {10, 10});
+
+ds <<= data_view;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR removes the reshapeable requirement from the container concept since it is usually not necessary and actively prohibits the use of containers with a static shape as a sink.

Instead, we require reshapeability only if the auto_reshape adaptor is used.