### PR TITLE
Improved error handling

### DIFF
--- a/src/hdf5/precursor/object_reference.cpp
+++ b/src/hdf5/precursor/object_reference.cpp
@@ -41,9 +41,9 @@ object_reference::object_reference(hid_t obj_id_)
 
     if (expected_len == 0)
     {
-        throw no_associated_name_exception("unable to obtain a reference;"
-                                           "no associated name is found",
-                                           obj_id_);
+        push_error_onto_stack(__FILE__, __FUNCTION__, __LINE__, get_echelon_error_class(),
+                              get_unable_to_obtain_ref_msg(), get_no_associated_name_msg(),
+                              "Unable to obtain a reference. No associated name is found.");
     }
     else if (expected_len < 0)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ if(ECHELON_BUILD_TESTS)
   target_include_directories(object_reference_handling PUBLIC ${Boost_INCLUDE_DIRS})
   target_compile_options(object_reference_handling PRIVATE ${COVERAGE_FLAGS})
   target_link_libraries(object_reference_handling echelon ${Boost_LIBRARIES}  ${COVERAGE_LINKER_FLAGS})
-  add_test(object_reference_handling ${CMAKE_CURRENT_BINARY_DIR}/error_handling)
+  add_test(object_reference_handling ${CMAKE_CURRENT_BINARY_DIR}/object_reference_handling)
 
   add_executable(error_handling error_handling.cpp)
   target_include_directories(error_handling PUBLIC ${Boost_INCLUDE_DIRS})

--- a/tests/error_handling.cpp
+++ b/tests/error_handling.cpp
@@ -16,8 +16,8 @@
 
 BOOST_FIXTURE_TEST_CASE( error_handling_test, basic_fixture )
 {
-    BOOST_CHECK_THROW(temp_file["bar"],echelon::hdf5::precursor::can_not_open_object_exception);
+    BOOST_CHECK_THROW(temp_file["bar"], echelon::hdf5::precursor::hdf5_error);
 
     temp_file.create_group("foo");
-    BOOST_CHECK_THROW(temp_file.create_group("foo"),echelon::hdf5::precursor::symbol_already_exists_exception);
+    BOOST_CHECK_THROW(temp_file.create_group("foo"), echelon::hdf5::precursor::hdf5_error);
 }

--- a/tests/object_reference_handling.cpp
+++ b/tests/object_reference_handling.cpp
@@ -23,10 +23,10 @@ BOOST_AUTO_TEST_CASE( scalar_object_reference_handling_test )
       auto sd3 = temp_file.create_scalar_dataset("scalar_dataset3", 3);
       auto sd4 = temp_file.create_scalar_dataset("scalar_dataset4", 4);
       
-      auto sd1_ref = temp_file.create_scalar_dataset("scalar_dataset1", sd1.ref());
-      auto sd2_ref = temp_file.create_scalar_dataset("scalar_dataset2", sd2.ref());
-      auto sd3_ref = temp_file.create_scalar_dataset("scalar_dataset3", sd3.ref());
-      auto sd4_ref = temp_file.create_scalar_dataset("scalar_dataset4", sd4.ref());
+      auto sd1_ref = temp_file.create_scalar_dataset("scalar_dataset_ref1", sd1.ref());
+      auto sd2_ref = temp_file.create_scalar_dataset("scalar_dataset_ref2", sd2.ref());
+      auto sd3_ref = temp_file.create_scalar_dataset("scalar_dataset_ref3", sd3.ref());
+      auto sd4_ref = temp_file.create_scalar_dataset("scalar_dataset_ref4", sd4.ref());
       
       echelon::object_reference ref1, ref2, ref3 ,ref4;
       

--- a/tests/require_api.cpp
+++ b/tests/require_api.cpp
@@ -12,13 +12,36 @@
 
 #include "basic_fixture.hpp"
 
-BOOST_FIXTURE_TEST_CASE( require_api, basic_fixture )
-{   
-      echelon::group g1 = temp_file.require_group("g1");
-    
-      BOOST_CHECK_NO_THROW(temp_file["g1"]);
-      
-      echelon::dataset ds1 = temp_file.create_dataset<double>("ds1",{ 10 , 10 });
-      
-      BOOST_CHECK_THROW(ds1 = temp_file.require_dataset<double>("ds1",{ 20 , 10 }),echelon::hdf5::broken_contract_exception);
+BOOST_AUTO_TEST_SUITE(require_api_suite)
+
+BOOST_FIXTURE_TEST_CASE(require_api, basic_fixture)
+{
+    echelon::group g1 = temp_file.require_group("g1");
+
+    BOOST_CHECK_NO_THROW(temp_file["g1"]);
+
+    echelon::dataset ds1 = temp_file.create_dataset<double>("ds1", {10, 10});
+
+    BOOST_CHECK_NO_THROW(temp_file["ds1"]);
+
+    BOOST_CHECK_THROW(ds1 = temp_file.require_dataset<double>("ds1", {20, 10}),
+                      echelon::hdf5::broken_contract_exception);
 }
+
+BOOST_FIXTURE_TEST_CASE(group_require_api, basic_fixture)
+{
+    echelon::group g = temp_file.create_group("g");
+
+    g.require_group("g1");
+
+    BOOST_CHECK_NO_THROW(g["g1"]);
+
+    g.require_dataset<double>("ds1", {10, 10});
+
+    BOOST_CHECK_NO_THROW(g["ds1"]);
+
+    BOOST_CHECK_THROW(g.require_dataset<double>("ds1", {20, 10}),
+        echelon::hdf5::broken_contract_exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The old system translated all errors into distinct exception classes which
turned out to be extremely brittle and unmaintainable since we needed to
manually specify the mapping for each (undocumented) error type.
Moreover, the HDF5 error types are extremely low-level and
it is unspecified which errors can occur during the execution of
an HDF5 function. Therefore, we have to assume that every error can occur
and don't gain much by introducing a rather arbitrary distinction between these
errors.

Instead, the new system only defines a single class for HDF5 errors, derived from
std::system_error, which encapsulates the informations about an error including the HDF5 error
codes. A distinct error category is introduced for HDF5 errors. This change simplifies the translation code and
makes the code more robust against the introduction of more error types.

The error stack is still translated into nested exceptions, one level for each error on the stack.

This PR works towards resolving issue #1.