### PR TITLE
Add missing `#include <string>`

### DIFF
--- a/src/hdf5/precursor/error_handling.cpp
+++ b/src/hdf5/precursor/error_handling.cpp
@@ -7,7 +7,7 @@
 
 #include <exception>
 #include <map>
-
+#include <string>
 #include <utility>
 #include <functional>
 #include <cassert>


### PR DESCRIPTION
Trying to build echelon without this `#include <string>` in place results in a litany of compilation errors about the implicit instantiation of the `std::basic_string<…>` template – adding it back in here fixes the issue.

N.B. I got the same compilation error when trying to build from the 0.7.0 release tarball